### PR TITLE
removed raise from pools controller

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -18,7 +18,6 @@ class PoolsController < ApplicationController
     if @pool.save
       redirect_to root_path
     else
-      raise
       render :new
     end
   end


### PR DESCRIPTION
Removed raise from pools_controller, it was done to enable in irb console at the html page, show @pools.errors.messages, to debug the code. it was sucessfully.